### PR TITLE
Fix bug for characters>127

### DIFF
--- a/main.c
+++ b/main.c
@@ -25,7 +25,7 @@ int main(int argc, char *argv[])
         }
     }
 
-    char bytes[16];
+    unsigned char bytes[16];
     int nread;
     unsigned offset = 0;
 
@@ -35,7 +35,7 @@ int main(int argc, char *argv[])
 
         for (int i = 0; i < nread; i++)
         {
-            fprintf(ofile, "%02x", bytes[i]);
+            fprintf(ofile, "%02hhx", bytes[i]);
             fputc(i != nread - 1 ? ' ' : '\n', ofile);
         }
         offset += nread;


### PR DESCRIPTION
When `char` is signed, the promotion from `bytes[i]` from `char` to `int` has unintended side-effects. This PR makes `bytes` an array of `unsigned char`, and, while at it, prints it with `%02hhx`.